### PR TITLE
Install python dependencies from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.109.0
 uvicorn[standard]==0.25.0
 pycrdt==0.8.1
-pycrdt-websocket==0.12.1
+pycrdt-websocket==0.12.4
 python-multipart==0.0.6
 jinja2==3.1.2


### PR DESCRIPTION
Update `pycrdt-websocket` version to resolve `pip install` error.

The previous version `0.12.1` was not found in the package index, causing installation failures. Updating to `0.12.4` resolves this by using the earliest available compatible version.

---
<a href="https://cursor.com/background-agent?bcId=bc-0264ab74-49f2-4974-8aa6-ec0cf9b5a2b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0264ab74-49f2-4974-8aa6-ec0cf9b5a2b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

