### PR TITLE
Check start.sh script validity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pycrdt==0.8.16
 pycrdt-websocket==0.13.0
 python-multipart==0.0.6
 jinja2==3.1.2
+websockets==12.0

--- a/server.py
+++ b/server.py
@@ -111,8 +111,7 @@ class CRDTWebSocketServer(WebsocketServer):
 
 # 전역 WebSocket 서버 인스턴스
 websocket_server = CRDTWebSocketServer(
-    auto_clean_rooms=False,
-    log_level="INFO"
+    auto_clean_rooms=False
 )
 
 
@@ -188,10 +187,13 @@ async def start_servers():
     http_port = int(os.environ.get('PORT', 8000))
     ws_port = int(os.environ.get('WEBSOCKET_PORT', 8765))
     
-    # WebSocket 서버 시작
-    websocket_task = asyncio.create_task(
-        websocket_server.start_websocket_server(host="0.0.0.0", port=ws_port)
-    )
+    # WebSocket 서버 시작을 위한 핸들러
+    async def websocket_handler(websocket, path):
+        await websocket_server.serve(websocket)
+    
+    # 표준 websockets 라이브러리로 서버 시작
+    import websockets
+    websocket_server_instance = await websockets.serve(websocket_handler, "0.0.0.0", ws_port)
     
     # FastAPI 서버 설정
     config = uvicorn.Config(

--- a/start.sh
+++ b/start.sh
@@ -10,14 +10,23 @@ if ! command -v python3 &> /dev/null; then
     exit 1
 fi
 
-# 가상환경 확인
-if [ ! -d "venv" ]; then
-    echo "❌ Virtual environment not found. Please run ./setup.sh first."
-    exit 1
+# 가상환경이 있으면 활성화
+if [ -d "venv" ] && [ -f "venv/bin/activate" ]; then
+    echo "🔌 Activating virtual environment..."
+    source venv/bin/activate
+else
+    echo "⚠️  Virtual environment not found. Checking system packages..."
+    
+    # 필수 패키지가 설치되어 있는지 확인
+    if ! python3 -c "import fastapi" 2>/dev/null; then
+        echo "❌ Required packages not found. Please install packages with:"
+        echo "   pip3 install --break-system-packages -r requirements.txt"
+        echo "   Or create a virtual environment first with:"
+        echo "   python3 -m venv venv"
+        exit 1
+    fi
+    echo "✅ Using system Python packages"
 fi
-
-# 가상환경 활성화
-source venv/bin/activate
 
 # .env 파일이 있으면 환경 변수 로드
 if [ -f ".env" ]; then
@@ -29,4 +38,4 @@ fi
 echo "🏃 Starting server..."
 echo "📄 HTTP Port: ${PORT:-8000}"
 echo "🔌 WebSocket Port: ${WEBSOCKET_PORT:-8765}"
-python server.py
+python3 server.py

--- a/websocket_server.py
+++ b/websocket_server.py
@@ -88,8 +88,7 @@ async def main():
     ws_port = int(os.environ.get('WEBSOCKET_PORT', 8765))
     
     server = CRDTWebSocketServer(
-        auto_clean_rooms=False,
-        log_level="INFO"
+        auto_clean_rooms=False
     )
     
     logger.info(f"Starting CRDT WebSocket server on port {ws_port}...")


### PR DESCRIPTION
Refactor server startup to ensure correct execution and compatibility with Python 3.13.

The original `start.sh` and `server.py` had multiple issues preventing the server from starting, including incorrect `pycrdt-websocket` API usage, a missing virtual environment setup, and Python 3.13 compatibility challenges with certain packages. This PR addresses these by modifying the startup script to be more robust and updating the WebSocket server initialization to use the standard `websockets` library.

---
<a href="https://cursor.com/background-agent?bcId=bc-07aaf9c8-15e6-42e3-bf31-8b185e15ef4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-07aaf9c8-15e6-42e3-bf31-8b185e15ef4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

