### PR TITLE
Fix missing static files directory in Azure

### DIFF
--- a/.deployment
+++ b/.deployment
@@ -1,0 +1,2 @@
+[config]
+SCM_DO_BUILD_DURING_DEPLOYMENT=true

--- a/main.py
+++ b/main.py
@@ -13,15 +13,19 @@ import uvicorn
 from pycrdt_websocket import WebsocketServer
 
 # 디렉토리 설정
-BASE_DIR = Path(__file__).parent
+BASE_DIR = Path(__file__).resolve().parent
 DATA_DIR = BASE_DIR / "data"
 DATA_DIR.mkdir(exist_ok=True)
+
+# static 디렉토리 생성
+STATIC_DIR = BASE_DIR / "static"
+STATIC_DIR.mkdir(exist_ok=True)
 
 # FastAPI 앱 설정
 app = FastAPI(title="Yjs + pycrdt-websocket 협업 시스템")
 
 # 정적 파일 및 템플릿 설정
-app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
+app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 # WebSocket 서버 인스턴스

--- a/server.py
+++ b/server.py
@@ -26,15 +26,39 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # 디렉토리 설정
-BASE_DIR = Path(__file__).parent
+# 기본 설정
+BASE_DIR = Path(__file__).resolve().parent
 DATA_DIR = BASE_DIR / "data"
 DATA_DIR.mkdir(exist_ok=True)
+
+# Azure App Service 환경 디버깅
+print(f"Current working directory: {os.getcwd()}")
+print(f"Script location: {__file__}")
+print(f"BASE_DIR: {BASE_DIR}")
+print(f"Directory contents: {list(BASE_DIR.glob('*'))}")
+
+# static 디렉토리 생성
+STATIC_DIR = BASE_DIR / "static"
+try:
+    STATIC_DIR.mkdir(exist_ok=True)
+    print(f"✅ Static directory created/verified: {STATIC_DIR}")
+except Exception as e:
+    print(f"⚠️ Warning: Could not create static directory: {e}")
+    # 대체 경로 시도
+    STATIC_DIR = Path("/tmp/static")
+    STATIC_DIR.mkdir(exist_ok=True)
+    print(f"✅ Using alternative static directory: {STATIC_DIR}")
 
 # FastAPI 앱 설정
 app = FastAPI(title="Yjs + pycrdt-websocket 협업 시스템")
 
 # 정적 파일 및 템플릿 설정
-app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
+if STATIC_DIR.exists():
+    app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+    print(f"✅ Static files mounted from: {STATIC_DIR}")
+else:
+    print("⚠️ Warning: Static directory not found, skipping static file mounting")
+    
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 

--- a/static/placeholder.txt
+++ b/static/placeholder.txt
@@ -1,0 +1,2 @@
+This is a placeholder file to ensure the static directory is included in deployments.
+You can safely delete this file after adding your own static assets.


### PR DESCRIPTION
Fixes Azure deployment error by ensuring the `static` directory is correctly included and referenced.

The `static` directory was not found during Azure App Service deployment, likely due to empty directory exclusion and incorrect path resolution after file extraction. This PR ensures the directory exists, is properly mounted, and is included in the deployment package.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9c602e5-b73c-47b7-b06f-9d8a25c8ed02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c9c602e5-b73c-47b7-b06f-9d8a25c8ed02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

