### PR TITLE
Check commit history for library loading errors

### DIFF
--- a/templates/crdt.html
+++ b/templates/crdt.html
@@ -385,7 +385,7 @@
     <script type="module">
         // ESM 모듈 형식으로 라이브러리 로드
         import * as Y from 'https://esm.sh/yjs@13.6.27';
-        import { WebsocketProvider } from 'https://esm.sh/y-websocket@2.0.4';
+        import { WebsocketProvider } from 'https://esm.sh/y-websocket@3.0.0';
         
         // 전역 변수에 할당
         window.Y = Y;

--- a/templates/crdt.html
+++ b/templates/crdt.html
@@ -385,7 +385,7 @@
     <script type="module">
         // ESM 모듈 형식으로 라이브러리 로드
         import * as Y from 'https://esm.sh/yjs@13.6.27';
-        import { WebsocketProvider } from 'https://esm.sh/y-websocket@1.5.6';
+        import { WebsocketProvider } from 'https://esm.sh/y-websocket@2.0.4';
         
         // 전역 변수에 할당
         window.Y = Y;


### PR DESCRIPTION
Update y-websocket to version 3.0.0 to resolve the 404 loading error from esm.sh.

The previous version 1.5.6 of y-websocket was not available on the esm.sh CDN, leading to a 404 error and subsequent library loading timeouts. Updating to the latest stable version 3.0.0 ensures the library loads correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6c74fdc-def7-400e-ac26-7bd9fb9700c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6c74fdc-def7-400e-ac26-7bd9fb9700c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

