### PR TITLE
Fix websocket security error

### DIFF
--- a/templates/crdt.html
+++ b/templates/crdt.html
@@ -577,7 +577,17 @@
             console.log('todos 배열 생성됨:', todos);
             
             // WebSocket 연결
-            const wsUrl = `ws://{{ websocket_host }}:{{ websocket_port }}/${roomName}`;
+            const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+            // Azure App Service에서는 WebSocket이 기본 포트를 통해 프록시됨
+            const isAzure = window.location.hostname.includes('azurewebsites.net');
+            let wsUrl;
+            if (isAzure) {
+                // Azure: FastAPI WebSocket 엔드포인트 사용
+                wsUrl = `${protocol}//{{ websocket_host }}/ws/${roomName}`;
+            } else {
+                // 로컬: 별도 WebSocket 서버 사용
+                wsUrl = `${protocol}//{{ websocket_host }}:{{ websocket_port }}/${roomName}`;
+            }
             console.log('WebSocket URL:', wsUrl);
             
             provider = new WebsocketProvider(wsUrl, roomName, ydoc, {


### PR DESCRIPTION
Fixes HTTPS/WSS Mixed Content error and enables WebSocket on Azure App Service.

The previous setup attempted insecure `ws://` connections from HTTPS pages, which browsers block. For Azure App Service, WebSocket traffic must be handled securely (`wss://`) on the main web port, requiring integration with the FastAPI server instead of a separate WebSocket server. This PR adapts the client and server to automatically use `wss://` when on HTTPS and routes WebSocket traffic through FastAPI's `/ws/{room_name}` endpoint on Azure.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9b0eaed-b9c1-4d87-bb87-6cb55559affa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9b0eaed-b9c1-4d87-bb87-6cb55559affa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

