### PR TITLE
Fix websocket connection error on azure

### DIFF
--- a/server.py
+++ b/server.py
@@ -208,17 +208,17 @@ async def crdt_page(request: Request, room: Optional[str] = None):
     )
 
 
-@app.websocket("/ws/{room_name}")
-async def websocket_endpoint(websocket: WebSocket, room_name: str):
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
     """WebSocket 엔드포인트 - Azure App Service용"""
     await websocket.accept()
     try:
         # pycrdt-websocket 서버와 연결
         await websocket_server.serve(websocket)
     except WebSocketDisconnect:
-        logger.info(f"Client disconnected from room {room_name}")
+        logger.info("Client disconnected")
     except Exception as e:
-        logger.error(f"WebSocket error in room {room_name}: {e}")
+        logger.error(f"WebSocket error: {e}")
         await websocket.close()
 
 

--- a/templates/crdt.html
+++ b/templates/crdt.html
@@ -583,12 +583,13 @@
             let wsUrl;
             if (isAzure) {
                 // Azure: FastAPI WebSocket 엔드포인트 사용
-                wsUrl = `${protocol}//{{ websocket_host }}/ws/${roomName}`;
+                wsUrl = `${protocol}//{{ websocket_host }}/ws`;
             } else {
                 // 로컬: 별도 WebSocket 서버 사용
-                wsUrl = `${protocol}//{{ websocket_host }}:{{ websocket_port }}/${roomName}`;
+                wsUrl = `${protocol}//{{ websocket_host }}:{{ websocket_port }}`;
             }
             console.log('WebSocket URL:', wsUrl);
+            console.log('Room name:', roomName);
             
             provider = new WebsocketProvider(wsUrl, roomName, ydoc, {
                 connect: true


### PR DESCRIPTION
Fix WebSocket connection failure by correcting URL construction and aligning server endpoint with `y-websocket` protocol.

The previous setup caused a `WebSocket connection failed` error due to the room name being duplicated in the URL and a mismatch in how the `y-websocket` client and `pycrdt-websocket` server expected room information. The client's `WebsocketProvider` sends the room name via protocol messages, not in the URL path.

---
<a href="https://cursor.com/background-agent?bcId=bc-11dbe57e-87df-4eae-91b7-06123df6bc2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-11dbe57e-87df-4eae-91b7-06123df6bc2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

