### PR TITLE
Investigate and fix internal server error

### DIFF
--- a/server.py
+++ b/server.py
@@ -276,7 +276,6 @@ async def crdt_page(request: Request, room: Optional[str] = None):
     context = {
         "request": request,
         "room_name": room,
-        "room_dir": ROOMS_DIR,
         "websocket_host": request.url.hostname or "localhost",
         "websocket_port": ws_port
     }


### PR DESCRIPTION
Remove undefined `ROOMS_DIR` from `/crdt` context to fix Internal Server Error.

---
<a href="https://cursor.com/background-agent?bcId=bc-4be3e114-36f5-48f1-b88b-42b76b567b2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4be3e114-36f5-48f1-b88b-42b76b567b2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

