### PR TITLE
Fix websocket connection error

### DIFF
--- a/server.py
+++ b/server.py
@@ -283,19 +283,21 @@ async def crdt_page(request: Request, room: Optional[str] = None):
     return templates.TemplateResponse("crdt.html", context)
 
 
-@app.websocket("/ws")
-async def websocket_endpoint(websocket: WebSocket):
+@app.websocket("/ws/{room_name:path}")
+async def websocket_endpoint(websocket: WebSocket, room_name: str):
     """WebSocket 엔드포인트 - Azure App Service용"""
     await websocket.accept()
     bridge = WebSocketBridge(websocket)
+    # pycrdt-websocket이 경로에서 room name을 추출하도록 설정
+    bridge.path = f"/{room_name}"
     
     try:
         # pycrdt-websocket 서버와 연결
         await websocket_server.serve(bridge)
     except WebSocketDisconnect:
-        logger.info("Client disconnected")
+        logger.info(f"Client disconnected from room: {room_name}")
     except Exception as e:
-        logger.error(f"WebSocket error: {e}", exc_info=True)
+        logger.error(f"WebSocket error in room {room_name}: {e}", exc_info=True)
         await bridge.close()
 
 


### PR DESCRIPTION
Fix WebSocket connection by updating server to handle room names in URL path.

The `y-websocket` library automatically appends the room name to the WebSocket URL (e.g., `wss://.../ws/hi`). The server's FastAPI endpoint was previously configured as `/ws`, leading to connection failures (code 1006). This change updates the endpoint to `/ws/{room_name:path}` to correctly capture the room name from the URL, allowing `pycrdt-websocket` to identify and manage rooms properly.

---
<a href="https://cursor.com/background-agent?bcId=bc-365fbdcd-f90c-48af-bad9-79b555c07f44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-365fbdcd-f90c-48af-bad9-79b555c07f44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

