### PR TITLE
Handle websocket connection status

### DIFF
--- a/server.py
+++ b/server.py
@@ -283,21 +283,19 @@ async def crdt_page(request: Request, room: Optional[str] = None):
     return templates.TemplateResponse("crdt.html", context)
 
 
-@app.websocket("/ws/{room_name:path}")
-async def websocket_endpoint(websocket: WebSocket, room_name: str):
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
     """WebSocket 엔드포인트 - Azure App Service용"""
     await websocket.accept()
     bridge = WebSocketBridge(websocket)
-    # pycrdt-websocket이 경로에서 room name을 추출하도록 설정
-    bridge.path = f"/{room_name}"
     
     try:
         # pycrdt-websocket 서버와 연결
         await websocket_server.serve(bridge)
     except WebSocketDisconnect:
-        logger.info(f"Client disconnected from room: {room_name}")
+        logger.info("Client disconnected")
     except Exception as e:
-        logger.error(f"WebSocket error in room {room_name}: {e}", exc_info=True)
+        logger.error(f"WebSocket error: {e}", exc_info=True)
         await bridge.close()
 
 

--- a/templates/crdt.html
+++ b/templates/crdt.html
@@ -583,10 +583,10 @@
             let wsUrl;
             if (isAzure) {
                 // Azure: FastAPI WebSocket 엔드포인트 사용 (room은 프로토콜로 전달)
-                wsUrl = `${protocol}//{{ websocket_host }}/ws/${roomName}`;
+                wsUrl = `${protocol}//{{ websocket_host }}/ws`;
             } else {
                 // 로컬: 별도 WebSocket 서버 사용
-                wsUrl = `${protocol}//{{ websocket_host }}:{{ websocket_port }}/${roomName}`;
+                wsUrl = `${protocol}//{{ websocket_host }}:{{ websocket_port }}`;
             }
             console.log('WebSocket URL:', wsUrl);
             console.log('Room name:', roomName);

--- a/templates/crdt.html
+++ b/templates/crdt.html
@@ -583,10 +583,10 @@
             let wsUrl;
             if (isAzure) {
                 // Azure: FastAPI WebSocket 엔드포인트 사용 (room은 프로토콜로 전달)
-                wsUrl = `${protocol}//{{ websocket_host }}/ws`;
+                wsUrl = `${protocol}//{{ websocket_host }}/ws/${roomName}`;
             } else {
                 // 로컬: 별도 WebSocket 서버 사용
-                wsUrl = `${protocol}//{{ websocket_host }}:{{ websocket_port }}`;
+                wsUrl = `${protocol}//{{ websocket_host }}:{{ websocket_port }}/${roomName}`;
             }
             console.log('WebSocket URL:', wsUrl);
             console.log('Room name:', roomName);


### PR DESCRIPTION
Fix repeated WebSocket disconnections by aligning server endpoint with y-websocket client protocol.

The previous server endpoint `/ws/{room_name:path}` expected the room name in the URL path. However, the `y-websocket` client library sends the room name as part of the WebSocket protocol messages, not in the URL. This mismatch led to immediate disconnections. This PR reverts the server endpoint to `/ws` to correctly handle room names via the y-websocket protocol.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e05cc1e-0228-46ba-bbda-d0f795c25963">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e05cc1e-0228-46ba-bbda-d0f795c25963">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

