### PR TITLE
Check and fix gps/view access

### DIFF
--- a/simpleServer.py
+++ b/simpleServer.py
@@ -16,9 +16,6 @@ from pycrdt import Doc, Text  # 누적 디코딩 및 통계 계산용
 #gps server
 # app.py (당신의 기존 FastAPI 엔트리)
 from gpssimple.fastapi_gps_router import router as gps_router
-
-app = FastAPI()
-app.include_router(gps_router, prefix="/gps")   # /gps/ingest, /gps/recent, /gps/latest, /gps/view
 #gps server end
 
 # -------------------------
@@ -320,6 +317,7 @@ async def lifespan(app: FastAPI):
         await task_server
 
 app = FastAPI(title="Yjs WebSocket (pycrdt-websocket)", lifespan=lifespan)
+app.include_router(gps_router, prefix="/gps")   # /gps/ingest, /gps/recent, /gps/latest, /gps/view
 
 @app.get("/")
 async def root():


### PR DESCRIPTION
Fixes unreachable `/gps/view` route by moving router inclusion to the final FastAPI app instance.

---
<a href="https://cursor.com/background-agent?bcId=bc-d229bc87-43ce-4df1-b713-0b887539d5da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d229bc87-43ce-4df1-b713-0b887539d5da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

